### PR TITLE
chore(ctx): NewRequestWithContext

### DIFF
--- a/gona/bgp.go
+++ b/gona/bgp.go
@@ -1,6 +1,7 @@
 package gona
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"strconv"
@@ -55,7 +56,7 @@ func (s *BGPSession) IsProviderIPTypeV4() bool {
 // GetBGPSession external method on Client to get your BGP session
 func (c *Client) GetBGPSession(id int) (*BGPSession, error) {
 	var sessions *BGPSession
-	err := c.get("bgp/bgpsession/"+strconv.Itoa(id), &sessions)
+	err := c.get(context.Background(), "bgp/bgpsession/"+strconv.Itoa(id), &sessions)
 	if err != nil {
 		return nil, err
 	}
@@ -67,7 +68,7 @@ func (c *Client) GetBGPSession(id int) (*BGPSession, error) {
 func (c *Client) GetBGPSessions(mbPkgID int) ([]*BGPSession, error) {
 	var allSessions []*BGPSession
 
-	err := c.get("bgp/bgpsessions", &allSessions)
+	err := c.get(context.Background(), "bgp/bgpsessions", &allSessions)
 	if err != nil {
 		return nil, err
 	}
@@ -127,7 +128,7 @@ func (c *Client) CreateBGPSessions(mbPkgID int, groupID int, isIPV6 bool, redund
 	}
 
 	var sessions *BGPSession
-	if err := c.post("bgp/bgpcreatesessions", postData, &sessions); err != nil {
+	if err := c.post(context.Background(), "bgp/bgpcreatesessions", postData, &sessions); err != nil {
 		return nil, fmt.Errorf("posting data: %w", err)
 	}
 

--- a/gona/client.go
+++ b/gona/client.go
@@ -4,6 +4,7 @@ package gona
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -84,7 +85,7 @@ func (c *Client) debugLog(format string, v ...any) {
 
 // get internal method on Client struct for providing the HTTP GET call
 func (c *Client) get(path string, data interface{}) error {
-	req, err := c.newRequest("GET", path, nil)
+	req, err := c.newRequest(context.Background(), "GET", path, nil)
 	if err != nil {
 		return err
 	}
@@ -95,7 +96,7 @@ func (c *Client) get(path string, data interface{}) error {
 func (c *Client) post(path string, values []byte, data interface{}) error {
 	c.debugLog("POST data for %s: %s", path, string(values))
 
-	req, err := c.newRequest("POST", path, bytes.NewBuffer(values))
+	req, err := c.newRequest(context.Background(), "POST", path, bytes.NewBuffer(values))
 	if err != nil {
 		return err
 	}
@@ -107,7 +108,7 @@ func (c *Client) post(path string, values []byte, data interface{}) error {
 
 // delete internal method on Client struct for providing the HTTP DELETE call
 func (c *Client) delete(path string, values url.Values, data interface{}) error {
-	req, err := c.newRequest("DELETE", path, nil)
+	req, err := c.newRequest(context.Background(), "DELETE", path, nil)
 	if err != nil {
 		return err
 	}
@@ -117,7 +118,7 @@ func (c *Client) delete(path string, values url.Values, data interface{}) error 
 // Two functions (newRequest, do) below are used by the http method name functions above
 // newRequest internal method on Client struct to be wrapped inside the above http method
 // named functions for doing the actual work of the get/post/put/patch/delete methods
-func (c *Client) newRequest(method string, path string, body io.Reader) (*http.Request, error) {
+func (c *Client) newRequest(ctx context.Context, method string, path string, body io.Reader) (*http.Request, error) {
 	relPath, err := url.Parse(apiKeyPath(path, c.apiKey))
 
 	if err != nil {
@@ -127,7 +128,7 @@ func (c *Client) newRequest(method string, path string, body io.Reader) (*http.R
 
 	url := c.endPoint.ResolveReference(relPath)
 
-	req, err := http.NewRequest(method, url.String(), body)
+	req, err := http.NewRequestWithContext(ctx, method, url.String(), body)
 	if err != nil {
 		return nil, err
 

--- a/gona/client.go
+++ b/gona/client.go
@@ -84,8 +84,8 @@ func (c *Client) debugLog(format string, v ...any) {
 }
 
 // get internal method on Client struct for providing the HTTP GET call
-func (c *Client) get(path string, data interface{}) error {
-	req, err := c.newRequest(context.Background(), "GET", path, nil)
+func (c *Client) get(ctx context.Context, path string, data interface{}) error {
+	req, err := c.newRequest(ctx, "GET", path, nil)
 	if err != nil {
 		return err
 	}
@@ -93,10 +93,10 @@ func (c *Client) get(path string, data interface{}) error {
 }
 
 // post internal method on Client struct for providing the HTTP POST call
-func (c *Client) post(path string, values []byte, data interface{}) error {
+func (c *Client) post(ctx context.Context, path string, values []byte, data interface{}) error {
 	c.debugLog("POST data for %s: %s", path, string(values))
 
-	req, err := c.newRequest(context.Background(), "POST", path, bytes.NewBuffer(values))
+	req, err := c.newRequest(ctx, "POST", path, bytes.NewBuffer(values))
 	if err != nil {
 		return err
 	}
@@ -107,8 +107,8 @@ func (c *Client) post(path string, values []byte, data interface{}) error {
 }
 
 // delete internal method on Client struct for providing the HTTP DELETE call
-func (c *Client) delete(path string, values url.Values, data interface{}) error {
-	req, err := c.newRequest(context.Background(), "DELETE", path, nil)
+func (c *Client) delete(ctx context.Context, path string, values url.Values, data interface{}) error {
+	req, err := c.newRequest(ctx, "DELETE", path, nil)
 	if err != nil {
 		return err
 	}

--- a/gona/ip.go
+++ b/gona/ip.go
@@ -1,6 +1,7 @@
 package gona
 
 import (
+	"context"
 	"strconv"
 
 	"inet.af/netaddr"
@@ -48,7 +49,7 @@ func (ips *IPs) GetIPsMap() *map[string]IPType {
 
 // GetIPs returns a list of IPs for the selected mbPkgID from the API
 func (c *Client) GetIPs(mbPkgID int) (ips IPs, err error) {
-	if err := c.get("cloud/networkips/"+strconv.Itoa(mbPkgID), &ips); err != nil {
+	if err := c.get(context.Background(), "cloud/networkips/"+strconv.Itoa(mbPkgID), &ips); err != nil {
 		return IPs{}, err
 	}
 

--- a/gona/locations.go
+++ b/gona/locations.go
@@ -1,5 +1,7 @@
 package gona
 
+import "context"
+
 // Location is an API response message of available deployment locations
 type Location struct {
 	ID        int    `json:"id"`
@@ -13,7 +15,7 @@ type Location struct {
 // GetLocations public method on Client to get a list of locations
 func (c *Client) GetLocations() ([]Location, error) {
 	r := make([]Location, 0)
-	if err := c.get("cloud/locations", &r); err != nil {
+	if err := c.get(context.Background(), "cloud/locations", &r); err != nil {
 		return nil, err
 	}
 	return r, nil

--- a/gona/os.go
+++ b/gona/os.go
@@ -1,5 +1,7 @@
 package gona
 
+import "context"
+
 // OS is a struct for storing the attributes of an OS
 type OS struct {
 	ID      int    `json:"id"`
@@ -14,7 +16,7 @@ type OS struct {
 // GetOSs returns a list of OS objects from the api
 func (c *Client) GetOSs() ([]OS, error) {
 	var osList []OS
-	if err := c.get("cloud/images", &osList); err != nil {
+	if err := c.get(context.Background(), "cloud/images", &osList); err != nil {
 		return nil, err
 	}
 	return osList, nil

--- a/gona/packages.go
+++ b/gona/packages.go
@@ -1,6 +1,9 @@
 package gona
 
-import "strconv"
+import (
+	"context"
+	"strconv"
+)
 
 // Package struct stores the purchaced package values
 type Package struct {
@@ -17,7 +20,7 @@ func (c *Client) GetPackages() ([]Package, error) {
 
 	var packageList []Package
 
-	if err := c.get("cloud/packages", &packageList); err != nil {
+	if err := c.get(context.Background(), "cloud/packages", &packageList); err != nil {
 		return nil, err
 	}
 
@@ -27,7 +30,7 @@ func (c *Client) GetPackages() ([]Package, error) {
 // GetPackage external method on Client that takes an id (int) as it's sole
 // argument and returns a single Package object
 func (c *Client) GetPackage(id int) (pkg Package, err error) {
-	if err := c.get("/cloud/package/"+strconv.Itoa(id), &pkg); err != nil {
+	if err := c.get(context.Background(), "/cloud/package/"+strconv.Itoa(id), &pkg); err != nil {
 		return Package{Installed: 0}, err
 	}
 	return pkg, nil

--- a/gona/plans.go
+++ b/gona/plans.go
@@ -1,5 +1,7 @@
 package gona
 
+import "context"
+
 // Plan struct defines the purchaceable plans/packages
 type Plan struct {
 	ID        int    `json:"plan_id,string"`
@@ -16,7 +18,7 @@ func (c *Client) GetPlans() ([]Plan, error) {
 
 	var planList []Plan
 
-	if err := c.get("cloud/sizes", &planList); err != nil {
+	if err := c.get(context.Background(), "cloud/sizes", &planList); err != nil {
 		return nil, err
 	}
 

--- a/gona/servers.go
+++ b/gona/servers.go
@@ -1,6 +1,7 @@
 package gona
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 
@@ -29,7 +30,7 @@ type Server struct {
 // GetServers external method on Client to list your instances
 func (c *Client) GetServers() ([]Server, error) {
 	var serverList []Server
-	if err := c.get("cloud/servers", &serverList); err != nil {
+	if err := c.get(context.Background(), "cloud/servers", &serverList); err != nil {
 		return nil, err
 	}
 	return serverList, nil
@@ -37,7 +38,7 @@ func (c *Client) GetServers() ([]Server, error) {
 
 // GetServer external method on Client to get an instance
 func (c *Client) GetServer(id int) (server Server, err error) {
-	if err := c.get("cloud/server?mbpkgid="+strconv.Itoa(id), &server); err != nil {
+	if err := c.get(context.Background(), "cloud/server?mbpkgid="+strconv.Itoa(id), &server); err != nil {
 		return server, err
 	}
 	return server, nil
@@ -76,7 +77,7 @@ func (c *Client) CreateServer(r *CreateServerRequest) (b ServerBuild, err error)
 		values.Add("script_type", "user-data")
 	}
 
-	if err := c.post("cloud/server/buy_build", []byte(values.Encode()), &b); err != nil {
+	if err := c.post(context.Background(), "cloud/server/buy_build", []byte(values.Encode()), &b); err != nil {
 		return b, err
 	}
 
@@ -113,7 +114,7 @@ func (c *Client) BuildServer(id int, r *BuildServerRequest) (b ServerBuild, err 
     //     values.Add("params", r.Params)
     // }
 
-	if err := c.post("cloud/server/build/"+strconv.Itoa(id), []byte(values.Encode()), &b); err != nil {
+	if err := c.post(context.Background(), "cloud/server/build/"+strconv.Itoa(id), []byte(values.Encode()), &b); err != nil {
 		return b, err
 	}
 
@@ -126,30 +127,22 @@ func (c *Client) DeleteServer(id int, cancelBilling bool) error {
 	if cancelBilling {
 		values.Add("cancel_billing", "1")
 	}
-	return c.post("cloud/server/delete?mbpkgid="+strconv.Itoa(id), []byte(values.Encode()), nil)
+	return c.post(context.Background(), "cloud/server/delete?mbpkgid="+strconv.Itoa(id), []byte(values.Encode()), nil)
 }
 
 // UnlinkServer external method on Client to unlink a billing package from a location
 func (c *Client) UnlinkServer(id int) error {
-	return c.post("cloud/server/unlink/"+strconv.Itoa(id), nil, nil)
+	return c.post(context.Background(), "cloud/server/unlink/"+strconv.Itoa(id), nil, nil)
 }
 
 // StartServer external method on Client to boot up an instance
 func (c *Client) StartServer(id int) error {
 
-	if err := c.post("cloud/server/start/"+strconv.Itoa(id), nil, nil); err != nil {
-		return err
-	}
-
-	return nil
+	return c.post(context.Background(), "cloud/server/start/"+strconv.Itoa(id), nil, nil)
 }
 
 // StopServer external method on Client to shut down an instance
 func (c *Client) StopServer(id int) error {
 
-	if err := c.post("cloud/server/shutdown/"+strconv.Itoa(id), nil, nil); err != nil {
-		return err
-	}
-
-	return nil
+	return c.post(context.Background(), "cloud/server/shutdown/"+strconv.Itoa(id), nil, nil)
 }

--- a/gona/sshkeys.go
+++ b/gona/sshkeys.go
@@ -1,6 +1,7 @@
 package gona
 
 import (
+	"context"
 	"net/url"
 	"strconv"
 )
@@ -16,7 +17,7 @@ type SSHKey struct {
 // GetSSHKeys will list all SSH Keys installed for the account
 func (c *Client) GetSSHKeys() (keys []SSHKey, err error) {
 	var sshkeyList []SSHKey
-	if err := c.get("account/ssh_keys", &sshkeyList); err != nil {
+	if err := c.get(context.Background(), "account/ssh_keys", &sshkeyList); err != nil {
 		return nil, err
 	}
 	return sshkeyList, nil
@@ -24,7 +25,7 @@ func (c *Client) GetSSHKeys() (keys []SSHKey, err error) {
 
 // GetSSHKey will list the information on a specific key
 func (c *Client) GetSSHKey(id int) (sshkey SSHKey, err error) {
-	if err := c.get("account/ssh_key/"+strconv.Itoa(id), &sshkey); err != nil {
+	if err := c.get(context.Background(), "account/ssh_key/"+strconv.Itoa(id), &sshkey); err != nil {
 		return SSHKey{}, err
 	}
 	return sshkey, nil
@@ -36,7 +37,7 @@ func (c *Client) CreateSSHKey(name, key string) (sshkey SSHKey, err error) {
 	values.Add("ssh_key", key)
 	values.Add("name", name)
 
-	if err := c.post("account/ssh_key", []byte(values.Encode()), &sshkey); err != nil {
+	if err := c.post(context.Background(), "account/ssh_key", []byte(values.Encode()), &sshkey); err != nil {
 		return SSHKey{}, err
 	}
 
@@ -45,8 +46,5 @@ func (c *Client) CreateSSHKey(name, key string) (sshkey SSHKey, err error) {
 
 // DeleteSSHKey deletes a key
 func (c *Client) DeleteSSHKey(id int) error {
-	if err := c.delete("account/ssh_key/"+strconv.Itoa(id), nil, nil); err != nil {
-		return err
-	}
-	return nil
+	return c.delete(context.Background(), "account/ssh_key/"+strconv.Itoa(id), nil, nil)
 }


### PR DESCRIPTION
non-breaking change to prepare for passing context from callers (e.g. terraform provider)

c.f. andyl-technologies/gona#6 andyl-technologies/terraform-provider-netactuate#10 for the breaking changes, where "breaking" means the exported API changes in a way requiring callers (e.g. terraform provider) to change