### PR TITLE
fix(package): fix absolute vs relative URL error

### DIFF
--- a/gona/packages.go
+++ b/gona/packages.go
@@ -27,7 +27,7 @@ func (c *Client) GetPackages() ([]Package, error) {
 // GetPackage external method on Client that takes an id (int) as it's sole
 // argument and returns a single Package object
 func (c *Client) GetPackage(id int) (pkg Package, err error) {
-	if err := c.get("/cloud/package/"+strconv.Itoa(id), &pkg); err != nil {
+	if err := c.get("cloud/package/"+strconv.Itoa(id), &pkg); err != nil {
 		return Package{Installed: 0}, err
 	}
 	return pkg, nil


### PR DESCRIPTION
per https://docs.netactuate.com/reference/get_cloud-package the url is `/api/cloud/package`, but the current library uses an absolute path and drops the `/api`