### PR TITLE
fix(client): avoid use, modification of http.DefaultClient

### DIFF
--- a/gona/client.go
+++ b/gona/client.go
@@ -44,13 +44,13 @@ func GetKeyFromEnv() string {
 // and returns the Client struct ready to talk to the API
 func NewClientCustom(apikey string, apiurl string) *Client {
 	useragent := "gona/" + Version
-	transport := &http.Transport{
-		TLSNextProto: make(
-			map[string]func(string, *tls.Conn) http.RoundTripper,
-		),
+	client := &http.Client{
+		Transport: &http.Transport{
+			TLSNextProto: make(
+				map[string]func(string, *tls.Conn) http.RoundTripper,
+			),
+		},
 	}
-	client := http.DefaultClient
-	client.Transport = transport
 	endpoint, _ := url.Parse(apiurl)
 
 	return &Client{
@@ -171,7 +171,7 @@ func (c *Client) do(req *http.Request, data interface{}) error {
 		return fmt.Errorf("could not unmarshal response %q: %w", string(body), err)
 	}
 
-  // Error Handling - This currently ignores invalid mbpkdgid errors to enable the Terraform Provider
+	// Error Handling - This currently ignores invalid mbpkdgid errors to enable the Terraform Provider
 	if (resp.StatusCode == 422 || r.Code == 422) && (r.Fields != nil && r.Fields["mbpkgid"] == nil) {
 		fieldStr := ""
 		for key, value := range r.Fields {


### PR DESCRIPTION
`http.DefaultClient` is a pointer to `http.Client`.
this library should not modify global state and this library should not rely on a pristine `http.Client`.
it may start out as a zero-value, but we have no idea what it is by the time we're creating clients.

consider the following scenarios:
- another library that set aggressive timeouts on `http.DefaultClient`
- a library that depends on default `TLSNextProto` behaviors that this code has modified
- order-of-operations changes where the behavior of this library depends on when it is called (or not called) over the life of a caller

instead, create our own zero-value client and modify that one.